### PR TITLE
fixed-color-ui-width-issue

### DIFF
--- a/color-ui.ftd
+++ b/color-ui.ftd
@@ -18,9 +18,9 @@ id: card-container
 
 --- ftd.row:
 if: $minimize
-scale: 0.6
-move-left: 100
-move-up: 250
+scale: 0.8
+move-left: 120
+move-up: 100
 width: fill
 
 --- ftd.row:

--- a/color-ui.ftd
+++ b/color-ui.ftd
@@ -30,21 +30,21 @@ if: not $is-mobile
 
 --- header:
 color: $color
-width: percent 33
+width: fill
 bg-color: $fpm.color.main.background.base
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text
 
 --- header:
 color: $color
-width: percent 34
+width: fill
 bg-color: $fpm.color.main.background.step-1
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text
 
 --- header:
 color: $color
-width: percent 33
+width: fill
 bg-color: $fpm.color.main.background.step-2
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text
@@ -63,21 +63,21 @@ if: not $is-mobile
 
 --- header:
 color: $color
-width: percent 33
+width: fill
 bg-color: $fpm.color.main.background.base
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text
 
 --- header:
 color: $color
-width: percent 34
+width: fill
 bg-color: $fpm.color.main.background.step-1
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text
 
 --- header:
 color: $color
-width: percent 33
+width: fill
 bg-color: $fpm.color.main.background.step-2
 page-heading: Set phasers on stun
 primary-body-text: $primary-body-text

--- a/color-ui.ftd
+++ b/color-ui.ftd
@@ -572,8 +572,9 @@ shadow-offset-y: 4
 shadow-size: 1
 shadow-blur: 2
 shadow-color: $fpm.color.main.success.border
+background-color: $fpm.color.main.background.base
 
 --- ftd.column:
-background-color: $fpm.color.main.background.base	
+	
 
 


### PR DESCRIPTION
Fixed the width issue of color doc (color-ui section)
![color-doc-before](https://user-images.githubusercontent.com/102805262/170034182-63628322-b67e-4cfb-9746-7562fa454154.png)
![color-doc-now](https://user-images.githubusercontent.com/102805262/170034189-17417a2b-5c45-44d6-a3e4-241dda9c104b.png)
updated color-ui scale for fpm.ftd
![fpm-color-ui2-before](https://user-images.githubusercontent.com/102805262/170258243-ffc32d97-4966-414d-b8cf-8753d16c6c35.png)
![fpm-color-ui2-now](https://user-images.githubusercontent.com/102805262/170258250-c9a74615-5d29-40ca-a268-119abe902ec5.png)
![fpm-color-ui-before](https://user-images.githubusercontent.com/102805262/170258252-b1f2964c-fc31-4709-89ce-bcbef91f7f4c.png)
![fpm-color-ui-now](https://user-images.githubusercontent.com/102805262/170258258-86937c6e-979d-4988-98a5-c8dbcbac867c.png)
